### PR TITLE
misc: Bump python version, split pip dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,33 @@
 # Stardew
 
-Bunch of experiments on lowering pytorch/tensorflow to mlir.
+Bunch of experiments on lowering PyTorch/Tensorflow to MLIR.
 
 ## Dev Setup
 
 ### Create Virtual Environment
 
-This was tested on python 3.10.9.
+This was tested on python 3.11.3
 
-```
+```sh
 python -m venv .env
 source .env/bin/activate
-pip install -r requirements
-pip install --editable .
+pip install -r requirements.txt --require-venv
+```
+Now for PyTorch experiments:
+```sh
+pip install -r requirements-torch.txt --require-venv
+```
+And/Or Tensorflow experiments:
+```sh
+pip install -r requirements-tf.txt --require-venv
+```
+Install Stardew
+```sh
+pip install --editable . --require-venv
 ```
 
 ### Running an example
 
-```
+```sh
 python -m examples.mlp_torch.main
 ```

--- a/requirements-tf.txt
+++ b/requirements-tf.txt
@@ -1,0 +1,2 @@
+# TensorFlow requirements
+tensorflow>2.0

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,0 +1,11 @@
+# For some reason this is required by torch-mlir
+packaging
+
+# Torch-MLIR
+-f https://llvm.github.io/torch-mlir/package-index/
+torch-mlir
+-f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+--pre
+torch
+torchvision
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,5 @@
-# IREE
+# t IREE
 -f https://iree-org.github.io/iree/pip-release-links.html
 iree-compiler
 iree-runtime
 iree-tools-tf
-
-# Torch-MLIR
--f https://llvm.github.io/torch-mlir/package-index/
-torch-mlir
--f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
---pre
-torch
-torchvision
-
-# TensorFlow
-tensorflow>2.0
-keras
-transformers


### PR DESCRIPTION
This PR bumps the python version to 3.11.3, since the previous version did not work for me.
It also splits the dependencies to use separate files for both tensorflow and pytorch.
The README has been updated accordingly