### PR TITLE
Update torch requirements to use latest nightlies

### DIFF
--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,7 +1,6 @@
 # Torch-MLIR
--f https://github.com/llvm/torch-mlir/releases/expanded_assets/snapshot-20230525.849
-torch-mlir==20230525.849
--f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
---pre
-torch==2.1.0.dev20230523+cpu
-torchvision==0.16.0.dev20230523+cpu
+--pre 
+-f https://llvm.github.io/torch-mlir/package-index/
+--extra-index-url https://download.pytorch.org/whl/nightly/cpu
+torch-mlir
+torchvision


### PR DESCRIPTION
The requirements for torch are outdated and no longer available. 
I suggest changing these requirements use the latest nightlies as suggested in the [torch-mlir repo](https://github.com/llvm/torch-mlir)
Using this configuration, the tests run fine for me.